### PR TITLE
[🔥AUDIT🔥] Replace references to Keeper with references to Google Secrets Manager.

### DIFF
--- a/jenkins_perf_visualizer/config.json
+++ b/jenkins_perf_visualizer/config.json
@@ -20,9 +20,9 @@
         //"username": "jenkins@khanacademy.org",
         //"passwordFile": "jenkins_api.token",
 
-        // Option 3: Specify a Keeper Security record-id that holds
-        //           the username and API token.
-        "keeperRecordId": "mHbUyJXAmnZyqLY3pMUmjQ"
+        // Option 3: Specify a GSM secret-name that holds the username
+        //           and API token.
+        "gsmRecordId": "jenkins_khanacademy_org_API_token_for_deploy_flamechart"
     },
 
     // -- OPTIONS RELATED TO GRAPH DATA.

--- a/jenkins_perf_visualizer/configuration.py
+++ b/jenkins_perf_visualizer/configuration.py
@@ -32,6 +32,7 @@ def add_download_threads_arg(parser):
         help=("How many threads to use when downloading, overriding the "
               "value in the config.json file"))
 
+
 def add_no_open_webpage_in_browser_arg(parser):
     parser.add_argument(
         '--no-open-webpage-in-browser', '-b', action='store_true',
@@ -111,8 +112,8 @@ def load(args):
             "username": args.jenkins_username,
             "passwordFile": args.jenkins_password_file,
         }
-    if hasattr(args, 'keeper_record_id'):
-        config['jenkinsAuth'] = {"keeperRecordId": args.keeper_record_id}
+    if hasattr(args, 'gsm_record_id'):
+        config['jenkinsAuth'] = {"gsmRecordId": args.gsm_record_id}
 
     if hasattr(args, 'grouping_parameter'):
         config['groupingParameter'] = args.grouping_parameter


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We're porting all our secrets from Keeper to GSM, and we need to
change our documentation (and code!) to match.  This is part of that
effort.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9448

## Test plan:
Ran this with success:
```
./visualize_jenkins_perf_data.py --config jenkins_perf_visualizer/config.json -d /var/tmp deploy/webapp-test:196522
```