### PR TITLE
[🔥AUDIT🔥] Run jenkins-perf-visualizer under python3.

### DIFF
--- a/download_jenkins_perf_data.py
+++ b/download_jenkins_perf_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Download and save the data-needed-to-render.
 

--- a/visualize_jenkins_perf_data.py
+++ b/visualize_jenkins_perf_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """Emit a chart that shows where time is spent during specified jenkins builds.
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
It looks like the script already supports both python2 and python3
(based on the import try/except in jenkins.py.)  So I just change the
drivers to explicitly use python3.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9839

## Test plan:
I ran `download_jenkins_perf_data.py` and it complained about my
inputs but at least ran.